### PR TITLE
Fix for exception being thrown on poor HL segment

### DIFF
--- a/src/Parser/X12Parser.php
+++ b/src/Parser/X12Parser.php
@@ -174,7 +174,10 @@ class X12Parser
                     $hl = new HL($dataElements);
 
                     // Determine which ST or HL segment this HL belongs to, and then add it
-                    $hlParentId = trim($hl->HL02);
+                    $hlParentId = '';
+                    if ($hl->HL02) {
+                        $hlParentId = trim($hl->HL02);
+                    }
                     $parent = $st;
                     if (strlen($hlParentId) > 0) {
                         $parent = $this->findHLParent($st->HL, $hlParentId);


### PR DESCRIPTION
Occasionally a file does not have an HL02, this is improper X12 but should not make the parser throw an exception.

This was mostly handled before with "if (strlen($hlParentId) > 0) {" but it the accessing HL02 when not existing will throw an exception