### PR TITLE
Add __isset() magic method for segments

### DIFF
--- a/src/EDI/Segments/Segment.php
+++ b/src/EDI/Segments/Segment.php
@@ -33,8 +33,7 @@ class Segment implements JsonSerializable
      *   $gs02 = isset($gs->GS02) ?? '';
      *
      * @param string $name
-     * @return mixed
-     * @throws Exception
+     * @return bool
      */
     public function __isset($name)
     {

--- a/src/EDI/Segments/Segment.php
+++ b/src/EDI/Segments/Segment.php
@@ -27,6 +27,30 @@ class Segment implements JsonSerializable
     }
 
     /**
+     * Magic method for detecting if elements of this segment are set.
+     * Example:
+     *   $gs = new GS(...);
+     *   $gs02 = isset($gs->GS02) ?? '';
+     *
+     * @param string $name
+     * @return mixed
+     * @throws Exception
+     */
+    public function __isset($name)
+    {
+        // Try to get a data element, ie: check for something like "GS02"
+        if (preg_match('/' . $this->getSegmentId() . '(\d+)/', $name, $matches)) {
+            $index = intval(ltrim($matches[1], '0'));
+            if ($index < count($this->dataElements)) {
+                return isset($this->dataElements[$index]);
+            }
+        }
+
+        // Not Found
+        return false;
+    }
+
+    /**
      * Magic method for accessing elements of this segment, such as "GS02".
      * Example:
      *   $gs = new GS(...);


### PR DESCRIPTION
This adds the ability to lean on PHP's isset() method on the Segments

For Example:

```php
$gs = new GS(...);
$gs02 = isset($gs->GS02) ?? '';
```

Previously, the above example would always set `$gs02` to the empty string as this would always result in `false`.