### PR TITLE
Feat/add utility class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
   },
   "require": {
     "php": "^8.3",
+    "nesbot/carbon": "^3.0",
     "webmozart/assert": "^1.10"
   },
   "require-dev": {

--- a/src/EDI/Utility.php
+++ b/src/EDI/Utility.php
@@ -16,6 +16,8 @@ class Utility
      *  5.40 => 5.4
      *  20.00 => 20
      *  0020.00 => 20
+     * 
+     * @return string
      */
     public static function generateX12MonetaryValue(string $amount)
     {

--- a/src/EDI/Utility.php
+++ b/src/EDI/Utility.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Uhin\X12Parser\EDI;
+
+use Carbon\Carbon;
+use Uhin\X12Parser\EDI\Segments\HL;
+use Uhin\X12Parser\EDI\Segments\ST;
+
+class Utility
+{
+    /**
+     * Will return the non-decimal version of the amount provided if it is not
+     *   necessary.
+     *
+     *  0.00 => 0
+     *  5.40 => 5.4
+     *  20.00 => 20
+     *  0020.00 => 20
+     */
+    public static function generateX12MonetaryValue(string $amount)
+    {
+        $amount = str_replace(',', '', $amount);
+        if (ltrim($amount, '-0.') === '') {
+            return '0';
+        }
+
+        $isNegative = str_starts_with($amount, '-');
+        
+        $amount = ltrim($amount, '-0');
+
+        if (str_contains($amount, '.')) {
+            $amount = rtrim($amount, '0');
+            $amount = rtrim($amount, '.');
+        }
+
+        return ($isNegative ? '-' : '') . $amount;
+    }
+
+    /**
+     * Translates from our date format standard to the X12 Standard
+     *
+     * @return string
+     */
+    public static function generateDTPFormatQualifier($format)
+    {
+        switch ($format) {
+            case 'time':
+                return 'TM';
+            case 'date':
+                return 'D8';
+            case 'datetime':
+                return 'DT';
+            case 'range_date':
+                return 'RD8';
+            case 'range_datetime':
+                return 'RDT';
+            default:
+                return $format;
+        }
+    }
+
+    /**
+     * Parses a date in the specified format
+     *
+     * @param  $datetime
+     * @param  $format
+     * @return string
+     */
+    public static function generateX12Time($date)
+    {
+        switch ($date->format) {
+            case 'time':
+                return Carbon::parse($date->time)->format('Hi');
+            case 'date':
+                return Carbon::parse($date->date)->format('Ymd');
+            case 'datetime':
+                return Carbon::parse($date->date.$date->time)->format('YmdHi');
+            case 'range_date':
+                return Carbon::parse($date->start_date)->format('Ymd')
+                    .'-'
+                    .Carbon::parse($date->end_date)->format('Ymd');
+            case 'range_datetime':
+                return Carbon::parse($date->start_date.$date->start_time)->format('YmdHi')
+                    .'-'
+                    .Carbon::parse($date->end_date.$date->end_time)->format('YmdHi');
+            default:
+                return $date;
+        }
+    }
+
+    /**
+     * @param ST $st
+     * @return integer
+     */
+    public static function countStSegments($st)
+    {
+        // 1 for ST segment, 1 for SE segment
+        $count = 2;
+
+        // Count the non-HL properties inside of this ST segment
+        $count += count($st->properties);
+
+        // Count the HL segments inside of this ST segment
+        if (isset($st->HL)) {
+            foreach ($st->HL as $hl) {
+                $count += self::countHlSegments($hl);
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * @param HL $hl
+     * @return integer
+     */
+    public static function countHlSegments($hl)
+    {
+        // 1 for this actual HL segment
+        $count = 1;
+
+        // Count the child HL segments
+        foreach ($hl->HL as $childHL) {
+            $count += self::countHlSegments($childHL);
+        }
+
+        // Count the non-HL child segments
+        $count += count($hl->properties);
+
+        return $count;
+    }
+}

--- a/tests/EDIUtilityTest.php
+++ b/tests/EDIUtilityTest.php
@@ -39,18 +39,14 @@ class EDIUtilityTest extends TestCase
     public function test_generate_dtp_format_qualifier_for_time_format()
     {
         $format = 'time';
-
         $result = $this->utility->generateDTPFormatQualifier($format);
-
         $this->assertEquals('TM', $result);
     }
 
     public function test_generate_dtp_format_qualifier_for_date_format()
     {
         $format = 'date';
-
         $result = $this->utility->generateDTPFormatQualifier($format);
-
         $this->assertEquals('D8', $result);
     }
 

--- a/tests/EDIUtilityTest.php
+++ b/tests/EDIUtilityTest.php
@@ -4,29 +4,146 @@ namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Uhin\X12Parser\EDI\Utility;
+use Uhin\X12Parser\Parser\X12Parser;
 
 class EDIUtilityTest extends TestCase
 {
+    private Utility $utility;
+
+    protected function setUp() : void
+    {
+        $this->utility = new Utility();
+    }
+
     public function test_generate_X12_monetary_value()
     {
-        $utility = new Utility();
+        $this->assertEquals($this->utility->generateX12MonetaryValue('0.00'), '0');
+        $this->assertEquals($this->utility->generateX12MonetaryValue('00.00'), '0');
+        $this->assertEquals($this->utility->generateX12MonetaryValue('0.0'), '0');
+        $this->assertEquals($this->utility->generateX12MonetaryValue('.0'), '0');
+        $this->assertEquals($this->utility->generateX12MonetaryValue('0.'), '0');
+        $this->assertEquals($this->utility->generateX12MonetaryValue('000.000'), '0');
+        $this->assertEquals($this->utility->generateX12MonetaryValue('1.23'), '1.23');
+        $this->assertEquals($this->utility->generateX12MonetaryValue('-1.23'), '-1.23');
+        $this->assertEquals($this->utility->generateX12MonetaryValue('1'), '1');
+        $this->assertEquals($this->utility->generateX12MonetaryValue('-1'), '-1');
+        $this->assertEquals($this->utility->generateX12MonetaryValue('0100'), '100');
+        $this->assertEquals($this->utility->generateX12MonetaryValue('1.00'), '1');
+        $this->assertEquals($this->utility->generateX12MonetaryValue('-1.00'), '-1');
+        $this->assertEquals($this->utility->generateX12MonetaryValue('0.50'), '.5');
+        $this->assertEquals($this->utility->generateX12MonetaryValue('-0.50'), '-.5');
+        $this->assertEquals($this->utility->generateX12MonetaryValue('01.23'), '1.23');
+        $this->assertEquals($this->utility->generateX12MonetaryValue('-01.23'), '-1.23');
+    }
 
-        $this->assertEquals($utility->generateX12MonetaryValue('0.00'), '0');
-        $this->assertEquals($utility->generateX12MonetaryValue('00.00'), '0');
-        $this->assertEquals($utility->generateX12MonetaryValue('0.0'), '0');
-        $this->assertEquals($utility->generateX12MonetaryValue('.0'), '0');
-        $this->assertEquals($utility->generateX12MonetaryValue('0.'), '0');
-        $this->assertEquals($utility->generateX12MonetaryValue('000.000'), '0');
-        $this->assertEquals($utility->generateX12MonetaryValue('1.23'), '1.23');
-        $this->assertEquals($utility->generateX12MonetaryValue('-1.23'), '-1.23');
-        $this->assertEquals($utility->generateX12MonetaryValue('1'), '1');
-        $this->assertEquals($utility->generateX12MonetaryValue('-1'), '-1');
-        $this->assertEquals($utility->generateX12MonetaryValue('0100'), '100');
-        $this->assertEquals($utility->generateX12MonetaryValue('1.00'), '1');
-        $this->assertEquals($utility->generateX12MonetaryValue('-1.00'), '-1');
-        $this->assertEquals($utility->generateX12MonetaryValue('0.50'), '.5');
-        $this->assertEquals($utility->generateX12MonetaryValue('-0.50'), '-.5');
-        $this->assertEquals($utility->generateX12MonetaryValue('01.23'), '1.23');
-        $this->assertEquals($utility->generateX12MonetaryValue('-01.23'), '-1.23');
+    public function test_generate_dtp_format_qualifier_for_time_format()
+    {
+        $format = 'time';
+
+        $result = $this->utility->generateDTPFormatQualifier($format);
+
+        $this->assertEquals('TM', $result);
+    }
+
+    public function test_generate_dtp_format_qualifier_for_date_format()
+    {
+        $format = 'date';
+
+        $result = $this->utility->generateDTPFormatQualifier($format);
+
+        $this->assertEquals('D8', $result);
+    }
+
+    public function test_generate_dtp_format_qualifier_for_datetime_format()
+    {
+        $format = 'datetime';
+        $result = $this->utility->generateDTPFormatQualifier($format);
+        $this->assertEquals('DT', $result);
+    }
+
+    public function test_generate_dtp_format_qualifier_for_range_date_format()
+    {
+        $format = 'range_date';
+        $result = $this->utility->generateDTPFormatQualifier($format);
+        $this->assertEquals('RD8', $result);
+    }
+
+    public function test_generate_dtp_format_qualifier_for_range_datetime_format()
+    {
+        $format = 'range_datetime';
+        $result = $this->utility->generateDTPFormatQualifier($format);
+        $this->assertEquals('RDT', $result);
+    }
+
+    public function test_generate_dtp_format_qualifier_returns_original_value_for_unknown_format()
+    {
+        $format = 'unknown';
+        $result = $this->utility->generateDTPFormatQualifier($format);
+        $this->assertEquals('unknown', $result);
+    }
+
+    public function test_generate_x12_time_for_time_format()
+    {
+        $date = (object) [
+            'format' => 'time',
+            'time' => '1970-01-01 01:30:00'
+        ];
+        $result = $this->utility->generateX12Time($date);
+        $this->assertEquals('0130', $result);
+    }
+
+    public function test_generate_x12_time_for_date_format()
+    {
+        $date = (object) [
+            'format' => 'date',
+            'date' => '1970-01-01'
+        ];
+        $result = $this->utility->generateX12Time($date);
+        $this->assertEquals('19700101', $result);
+    }
+
+    public function test_generate_x12_time_for_datetime_format()
+    {
+        $date = (object) [
+            'format' => 'datetime',
+            'date' => '1970-01-01',
+            'time' => '01:30:00'
+        ];
+        $result = $this->utility->generateX12Time($date);
+        $this->assertEquals('197001010130', $result);
+    }
+
+    public function test_generate_x12_time_for_range_date_format()
+    {
+        $date = (object) [
+            'format' => 'range_date',
+            'start_date' => '1970-01-01',
+            'end_date' => '2000-01-01'
+        ];
+        $result = $this->utility->generateX12Time($date);
+        $this->assertEquals('19700101-20000101', $result);
+    }
+
+    public function test_generate_x12_time_for_range_datetime_format()
+    {
+        $date = (object) [
+            'format' => 'range_datetime',
+            'start_date' => '1970-01-01',
+            'start_time' => '01:30:00',
+            'end_date' => '2000-01-01',
+            'end_time' => '01:30:00'
+        ];
+        $result = $this->utility->generateX12Time($date);
+        $this->assertEquals('197001010130-200001010130', $result);
+    }
+
+    public function test_generate_x12_time_returns_original_value_for_unknown_format()
+    {
+        $date = (object) [
+            'format' => 'unknown',
+            'time' => '013000'
+        ];
+        $result = $this->utility->generateX12Time($date);
+        $this->assertEquals($date, $result);
     }
 }

--- a/tests/EDIUtilityTest.php
+++ b/tests/EDIUtilityTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Uhin\X12Parser\EDI\Utility;
+
+class EDIUtilityTest extends TestCase
+{
+    public function test_generate_X12_monetary_value()
+    {
+        $utility = new Utility();
+
+        $this->assertEquals($utility->generateX12MonetaryValue('0.00'), '0');
+        $this->assertEquals($utility->generateX12MonetaryValue('00.00'), '0');
+        $this->assertEquals($utility->generateX12MonetaryValue('0.0'), '0');
+        $this->assertEquals($utility->generateX12MonetaryValue('.0'), '0');
+        $this->assertEquals($utility->generateX12MonetaryValue('0.'), '0');
+        $this->assertEquals($utility->generateX12MonetaryValue('000.000'), '0');
+        $this->assertEquals($utility->generateX12MonetaryValue('1.23'), '1.23');
+        $this->assertEquals($utility->generateX12MonetaryValue('-1.23'), '-1.23');
+        $this->assertEquals($utility->generateX12MonetaryValue('1'), '1');
+        $this->assertEquals($utility->generateX12MonetaryValue('-1'), '-1');
+        $this->assertEquals($utility->generateX12MonetaryValue('0100'), '100');
+        $this->assertEquals($utility->generateX12MonetaryValue('1.00'), '1');
+        $this->assertEquals($utility->generateX12MonetaryValue('-1.00'), '-1');
+        $this->assertEquals($utility->generateX12MonetaryValue('0.50'), '.5');
+        $this->assertEquals($utility->generateX12MonetaryValue('-0.50'), '-.5');
+        $this->assertEquals($utility->generateX12MonetaryValue('01.23'), '1.23');
+        $this->assertEquals($utility->generateX12MonetaryValue('-01.23'), '-1.23');
+    }
+}

--- a/tests/EDIUtilityTest.php
+++ b/tests/EDIUtilityTest.php
@@ -142,4 +142,44 @@ class EDIUtilityTest extends TestCase
         $result = $this->utility->generateX12Time($date);
         $this->assertEquals($date, $result);
     }
+
+    public function test_count_st_segments()
+    {
+        $filePath = __DIR__ . '/test-files/837.edi';
+        $this->assertFileExists($filePath);
+        $fileContents = file_get_contents($filePath);
+        $fileContents = str_replace(["\n", "\t", "\r"], '', $fileContents);
+        $parser = new X12Parser($fileContents);
+        $x12 = $parser->parse();
+
+        foreach ($x12->ISA as $isa) {
+            foreach ($isa->GS as $gs) {
+                foreach ($gs->ST as $st) {
+                    $result = $this->utility->countStSegments($st);
+                    $this->assertEquals(24, $result);
+                }
+            }
+        }
+    }
+
+    public function test_count_hl_segments()
+    {
+        $filePath = __DIR__ . ('/test-files/837.edi');
+        $this->assertFileExists($filePath);
+        $fileContents = file_get_contents($filePath);
+        $fileContents = str_replace(["\n", "\t", "\r"], '', $fileContents);
+        $parser = new X12Parser($fileContents);
+        $x12 = $parser->parse();
+
+        foreach ($x12->ISA as $isa) {
+            foreach ($isa->GS as $gs) {
+                foreach ($gs->ST as $st) {
+                    foreach ($st->HL as $hl) {
+                        $result = $this->utility->countHLSegments($hl);
+                        $this->assertEquals(18, $result);
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Related task(s):
https://www.notion.so/uhin/MYUHIN-Claims-Fix-Leading-Zeroes-Bug-32e664781d1a80f8896de38a9af984d3

- Adds utility class to handle X12 data transformation and counting segments.
- Adds test for generating X12 monetary values.

Tested locally and in development.